### PR TITLE
fix: remove reference to example.production.env

### DIFF
--- a/docs/integrate-payid-users.md
+++ b/docs/integrate-payid-users.md
@@ -36,7 +36,7 @@ The reference implementation described in [Getting Started](getting-started) use
 
 ## Set environment variables
 
-PayID depends on environment variables. All of these environment variables are read in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) and assigned to variables. During integration, look through all of the environment variables used in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) and [example.production.env](https://github.com/xpring-eng/payid/blob/master/example.production.env) to ensure all are set properly for your environment.
+PayID depends on environment variables. All of these environment variables are read in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) and assigned to variables. During integration, look through all of the environment variables used in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) to ensure all are set properly for your environment.
 
 ## Update database migrations
 


### PR DESCRIPTION
## High Level Overview of Change

This PR https://github.com/xpring-eng/payid/pull/503 removed `example.production.env`, this PR updates docs to remove references to it.

### Context of Change

Just making sure docs are properly updated.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

## Before / After

Removed reference to `example.production.env`

## Test Plan
 No tests