### PR TITLE
Update incorrect GH link

### DIFF
--- a/docs/remote-deployment.md
+++ b/docs/remote-deployment.md
@@ -33,7 +33,7 @@ You can set up a PayID server on AWS (Amazon Web Services).
    sudo apt install docker.io
    ```
 9. Clone the payid Github repository.
-   `git clone git@github.com:xpring-eng/payid.git`
+   `git clone git@github.com:payid-org/payid.git`
 10. Set the docker port to 80 by modifying the demo script.
     - Open the script editor: `nano payid/demo/run_payid_demo.sh`
     - Change the line:


### PR DESCRIPTION
## High Level Overview of Change

Still referenced `xpring-eng/payid` instead of `payid-org/payid` so I fixed it.

### Context of Change

Deprecated docs

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release