### PR TITLE
fix: outdated links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ Ensure that you follow the [recommended best practices](payid-best-practices) fo
 To set up a PayID server to develop some other server against, such as the Xpring Wallet, run these commands.
 
 ```bash
-git clone git@github.com:xpring-eng/payid.git
+git clone git@github.com:payid-org/payid.git
 npm run devEnvUp
 ```
 

--- a/docs/integrate-payid-users.md
+++ b/docs/integrate-payid-users.md
@@ -8,21 +8,21 @@ If you have an existing user database, you can take the following steps to integ
 
 ## Extend existing database tables with new columns
 
-The PayID [account schema](https://github.com/xpring-eng/payid/blob/master/src/db/schema/01_account.sql) is used to define a table for users.
+The PayID [account schema](https://github.com/payid-org/payid/blob/master/src/db/schema/01_account.sql) is used to define a table for users.
 
 The account table contains two fields: `id` and `pay_id`. The address table uses a foreign key column called `account_id` which depends on id as a foreign key to associate addresses with individual accounts. The second column is `pay_id` which is where we store the string identifier (such as `alice$wallet.com`).
 
 With an existing user database, you will need to add the `pay_id` column. Your user database might already have the equivalent of an `id` field, but if not, add this column so that each address can reference a specific user.
 
-The PayID account schema has three constraints that could be useful to apply to your existing user database. Two constraints guarantee that all entered PayIDs are lowercase and are not empty strings. The final and most important constraint is that the regex constraint `valid_pay_id` guarantees that all entered PayIDs are in compliance with the format outlined in the [PayID whitepaper](https://github.com/xpring-eng/payid/blob/master/docs/whitepaper_v2.0.0.pdf).
+The PayID account schema has three constraints that could be useful to apply to your existing user database. Two constraints guarantee that all entered PayIDs are lowercase and are not empty strings. The final and most important constraint is that the regex constraint `valid_pay_id` guarantees that all entered PayIDs are in compliance with the format outlined in the [PayID whitepaper](https://github.com/payid-org/payid/blob/master/docs/whitepaper_v2.0.0.pdf).
 
-The PayID [address schema](https://github.com/xpring-eng/payid/blob/master/src/db/schema/02_address.sql) is used to define a table of addresses associated with users.
+The PayID [address schema](https://github.com/payid-org/payid/blob/master/src/db/schema/02_address.sql) is used to define a table of addresses associated with users.
 
 Whenever a PayID is queried, the payment network and environment are sent via an Accept header. Therefore, it is important that each address stored has an associated payment network and environment. For example, upon receipt of the accept header `application/xrpl-testnet+json` you should query your address table for the address associated with the `xrpl` payment network and `testnet` environment.
 
 ## Match column names in data access functions
 
-All functions that query the database are located in [https://github.com/xpring-eng/payid/tree/master/src/data-access](https://github.com/xpring-eng/payid/tree/master/src/data-access). If you use column names that do not match the [schema](https://github.com/xpring-eng/payid/tree/master/src/db/schema), then you must reflect those changes in the data access functions. The following table lists the files contained within [https://github.com/xpring-eng/payid/tree/master/src/data-access](https://github.com/xpring-eng/payid/tree/master/src/data-access) and the corresponding column names they use:
+All functions that query the database are located in [https://github.com/payid-org/payid/tree/master/src/data-access](https://github.com/payid-org/payid/tree/master/src/data-access). If you use column names that do not match the [schema](https://github.com/payid-org/payid/tree/master/src/db/schema), then you must reflect those changes in the data access functions. The following table lists the files contained within [https://github.com/payid-org/payid/tree/master/src/data-access](https://github.com/payid-org/payid/tree/master/src/data-access) and the corresponding column names they use:
 
 | File name                  | Columns used                                                                                                  |
 | -------------------------- | :------------------------------------------------------------------------------------------------------------ |
@@ -32,11 +32,11 @@ All functions that query the database are located in [https://github.com/xpring-
 
 ## Change the type of database
 
-The reference implementation described in [Getting Started](getting-started) uses a Postgres database. To use a different type of database, either update the settings in the [knexfile](https://github.com/xpring-eng/payid/blob/master/src/db/knex.ts), or replace the use of `knex` throughout the repository with your preferred database connection tool.
+The reference implementation described in [Getting Started](getting-started) uses a Postgres database. To use a different type of database, either update the settings in the [knexfile](https://github.com/payid-org/payid/blob/master/src/db/knex.ts), or replace the use of `knex` throughout the repository with your preferred database connection tool.
 
 ## Set environment variables
 
-PayID depends on environment variables. All of these environment variables are read in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) and assigned to variables. During integration, look through all of the environment variables used in [src/config.ts](https://github.com/xpring-eng/payid/blob/master/src/config.ts) to ensure all are set properly for your environment.
+PayID depends on environment variables. All of these environment variables are read in [src/config.ts](https://github.com/payid-org/payid/blob/master/src/config.ts) and assigned to variables. During integration, look through all of the environment variables used in [src/config.ts](https://github.com/payid-org/payid/blob/master/src/config.ts) to ensure all are set properly for your environment.
 
 ## Update database migrations
 
@@ -44,4 +44,4 @@ If you use your own database, there are migration files written specifically for
 
 ## Update SQL files
 
-The `.sql` files within [src/db](https://github.com/xpring-eng/payid/tree/master/src/db) are each executed by the function `syncDatabaseSchema` located in [src/db/syncDatabaseSchema.ts](https://github.com/xpring-eng/payid/blob/master/src/db/syncDatabaseSchema.ts). To integrate into an existing system, be sure to look through the directories in [src/db](https://github.com/xpring-eng/payid/blob/master/src/db/) to identify any `.sql` files that you need to modify to fit your existing system, or to remove because they do not apply.
+The `.sql` files within [src/db](https://github.com/payid-org/payid/tree/master/src/db) are each executed by the function `syncDatabaseSchema` located in [src/db/syncDatabaseSchema.ts](https://github.com/payid-org/payid/blob/master/src/db/syncDatabaseSchema.ts). To integrate into an existing system, be sure to look through the directories in [src/db](https://github.com/payid-org/payid/blob/master/src/db/) to identify any `.sql` files that you need to modify to fit your existing system, or to remove because they do not apply.

--- a/docs/local-deployment.md
+++ b/docs/local-deployment.md
@@ -22,7 +22,7 @@ Ensure your system meets these requirements before you set up a PayID server.
 Before you begin, make sure that you have installed Postgres locally, or in an otherwise accessible location.
 
 1. Clone the PayID repo.
-   `git clone https://github.com/xpring-eng/payid.git && cd payid`
+   `git clone https://github.com/payid-org/payid.git && cd payid`
 2. Install dependencies.
 
    `npm i`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -113,7 +113,7 @@ Install the following software on your machine, if not already present.
 Run these commands to build a Docker container for a PayID server.
 
 ```bash
-git clone git@github.com:xpring-eng/payid.git
+git clone git@github.com:payid-org/payid.git
 cd payid
 docker build -t payid-server .
 ```

--- a/docs/payid-overview.md
+++ b/docs/payid-overview.md
@@ -14,7 +14,7 @@ PayID is fully peer-to-peer with no central counterparty. Anyone can set up thei
 
 The PayID protocol is designed to be simple, general, open, and universal. This makes it composable with any other existing namespace, including blockchain namespace projects like ENS and Unstoppable Domains or app-specific usernames. Anyone with an existing username or address can get a PayID address that works across all platforms.
 
-Check out the [PayID repository on Github](https://github.com/xpring-eng/payid/). Refer to [Getting started](getting-started) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
+Check out the [PayID repository on Github](https://github.com/payid-org/payid/). Refer to [Getting started](getting-started) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
 
 ## Web standards
 
@@ -42,7 +42,7 @@ PayID is an extensible and flexible open standard, and therefore can be used as 
 
 Verifiable PayID is a suite of security enhancements to the base PayID request and response that adds in a variety of digital signature fields for linking external digital identities, proving control of the payment rail address, and providing non-repudiable messaging. It can be used to enable trust-minimized and trust-free security regimes and has applications in both custodial and non-custodial settings.
 
-To learn more, please see the [Verifiable PayID RFC](https://github.com/xpring-eng/rfcs/blob/master/payid/dist/spec/verifiable-payid-protocol.txt).
+To learn more, please see the [Verifiable PayID RFC](https://github.com/payid-org/rfcs/blob/master/payid/dist/spec/verifiable-payid-protocol.txt).
 
 ### Compliance and Travel Rule
 


### PR DESCRIPTION
## High Level Overview of Change

shifts references from `xpring-eng/payid` to `payid-org/payid`

### Context of Change

We migrated the repo so this updates those links.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release