### PR TITLE
Fixing a broken link URI to best practices

### DIFF
--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -4,7 +4,7 @@ title: Community Tools for PayID
 sidebar_label: Community Tools
 ---
 
-The [PayID Validator](https://payidvalidator.com/) is an [open-source project](https://github.com/rswarthout/payid-validator) that validates responses using [JSON schemas](https://docs.payid.org/payid-interfaces) and verifies whether your PayID server follows various [best practices](best-practices), like:
+The [PayID Validator](https://payidvalidator.com/) is an [open-source project](https://github.com/rswarthout/payid-validator) that validates responses using [JSON schemas](https://docs.payid.org/payid-interfaces) and verifies whether your PayID server follows various [best practices](payid-best-practices), like:
 
 - [HTTP response headers](payid-headers)
 - [Cache-Control](https://docs.payid.org/payid-best-practices#cache-control)


### PR DESCRIPTION
Fixing a broken link on the Community Tools page.