### PR TITLE
add skeleton page pointing to Github release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,11 @@
+---
+id: release-notes
+title: Release Notes
+sidebar_label: Release Notes
+---
+
+Release notes are stored on Github.
+
+* [PayID 1.3 - August 18, 2020](https://github.com/payid-org/payid/releases/tag/v1.3.0) - Support for self-sovereign verifiable PayID.
+* [PayID 1.2 - August 4, 2020](https://github.com/payid-org/payid/releases/tag/v1.2.0) - Support for PayID Discovery, and the addition of the PATCH method to the Public API.
+* [See all release tags](https://github.com/payid-org/payid/tags).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,8 +4,9 @@ title: Release Notes
 sidebar_label: Release Notes
 ---
 
-Release notes are stored on Github.
+See release notes for the last two releases:
 
 - [PayID 1.3 - August 18, 2020](https://github.com/payid-org/payid/releases/tag/v1.3.0) - Support for self-sovereign verifiable PayID.
 - [PayID 1.2 - August 4, 2020](https://github.com/payid-org/payid/releases/tag/v1.2.0) - Support for PayID Discovery, and the addition of the PATCH method to the Public API.
-- [See all release tags](https://github.com/payid-org/payid/tags).
+
+See [all release notes on Github](https://github.com/payid-org/payid/tags).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,6 @@ sidebar_label: Release Notes
 
 Release notes are stored on Github.
 
-* [PayID 1.3 - August 18, 2020](https://github.com/payid-org/payid/releases/tag/v1.3.0) - Support for self-sovereign verifiable PayID.
-* [PayID 1.2 - August 4, 2020](https://github.com/payid-org/payid/releases/tag/v1.2.0) - Support for PayID Discovery, and the addition of the PATCH method to the Public API.
-* [See all release tags](https://github.com/payid-org/payid/tags).
+- [PayID 1.3 - August 18, 2020](https://github.com/payid-org/payid/releases/tag/v1.3.0) - Support for self-sovereign verifiable PayID.
+- [PayID 1.2 - August 4, 2020](https://github.com/payid-org/payid/releases/tag/v1.2.0) - Support for PayID Discovery, and the addition of the PATCH method to the Public API.
+- [See all release tags](https://github.com/payid-org/payid/tags).

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,5 +39,10 @@ module.exports = {
       label: 'PayID Tooling',
       items: ['xpring-sdk-payid', 'community-resources'],
     },
+    {
+      type: 'category',
+      label: 'Release Notes',
+      items: ['release-notes'],
+    }
   ],
 }


### PR DESCRIPTION
## High Level Overview of Change

We want to avoid duplication, but we also want to surface release notes. I'm open to another solution, but for now, this is what I suggest:
* Link directly to the last two release note sets.
* Provide a link to all of the release tags. 

### Context of Change

We want readers to immediately be able to find release notes. 

### Type of Change

- [x ] Documentation Updates

## Before / After

Addition of release notes page. Added to sidebar for visibility. 

## Test Plan

Built this change locally.

## Future Tasks
Consider automating the task of linking to the last two releases, and otherwise manually update it.
