### PR TITLE
changed form of reference and removed indenting to improve formatting

### DIFF
--- a/docs/payid-cli.md
+++ b/docs/payid-cli.md
@@ -21,7 +21,7 @@ This command installs PayID CLI as a global npm module and links it as a payid e
 
 To install and run PayID CLI from Docker, run:
 
-    `docker run xpring/payid-cli`
+`docker run xpring/payid-cli`
 
 ## Run PayID CLI in interactive or single-command mode
 
@@ -30,18 +30,18 @@ To run PayID CLI in interactive mode, run `payid` to open an interactive session
 In interactive mode, you can then run PayID CLI commands as desired with the form
 `<command> <arguments>`, such as:
 
-    `load 'nhartner$xpring.money'`
+`load 'nhartner$xpring.money'`
 
 To exit interactive mode, run `exit`.
 
 To run PayID CLI in single-command mode, prefix each command with `payid`. Each command takes the form
 `payid <command> <arguments>`, such as:
 
-    `payid load 'nhartner$xpring.money'`
+`payid load 'nhartner$xpring.money'`
 
 Use single-command mode for scripts, or to chain the results of multiple commands together, such as:
 
-    `payid init 'my$pay.id' && payid crypto-address add btc mainnet notARealAddress && payid save`
+`payid init 'my$pay.id' && payid crypto-address add btc mainnet notARealAddress && payid save`
 
 When you pass a PayID as an argument in non-interactive mode, make sure to escape or quote the PayID to avoid the `'$'` being interpolated as a variable by the shell.
 

--- a/docs/payid-overview.md
+++ b/docs/payid-overview.md
@@ -26,7 +26,7 @@ Refer to the [PayID protocol whitepaper](https://payid.org/whitepaper.pdf) for a
 
 ## Implementations
 
-You can decide how you want to implement the PayID protocol. To facilitate ease of use, Xpring has created a [reference implementation for a PayID server](payid-reference-overview). Check out the [PayID repository on Github](https://github.com/xpring-eng/payid/). Refer to [Getting started](/) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
+You can decide how you want to implement the PayID protocol. To facilitate ease of use, Xpring has created a [reference implementation for a PayID server](../payid-reference-overview). Check out the [PayID repository on Github](https://github.com/xpring-eng/payid/). Refer to [Getting started](/) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
 
 If you want to contribute to PayID, see [Contributing to PayID](https://github.com/payid-org/payid/blob/master/CONTRIBUTING.md).
 

--- a/docs/payid-overview.md
+++ b/docs/payid-overview.md
@@ -26,7 +26,7 @@ Refer to the [PayID protocol whitepaper](https://payid.org/whitepaper.pdf) for a
 
 ## Implementations
 
-You can decide how you want to implement the PayID protocol. To facilitate ease of use, Xpring has created a [reference implementation for a PayID server](../payid-reference-overview). Check out the [PayID repository on Github](https://github.com/xpring-eng/payid/). Refer to [Getting started](/) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
+You can decide how you want to implement the PayID protocol. To facilitate ease of use, Xpring has created a [reference implementation for a PayID server](payid-reference-overview). Check out the [PayID repository on Github](https://github.com/xpring-eng/payid/). Refer to [Getting started](/) for a quick guide to deploy your own PayID server, manage users, and execute transactions.
 
 If you want to contribute to PayID, see [Contributing to PayID](https://github.com/payid-org/payid/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
## High Level Overview of Change

The reference "[reference implementation for a PayID server](payid-reference-overview)" in payid-overview works locally, b ut not online at docs.payid.org, where it adds an extra payid-overview folder. I made a change locally to "[reference implementation for a PayID server](../payid-reference-overview)"  that continues to work locally, but I won't be able to test this until I deploy at dev.docs.payid.org. 

In addition, I cleaned up indenting that caused formatting to appear oddly in payid-cli.

### Context of Change

Fix link, fix formatting.

### Type of Change

- [x ] Documentation Updates


## Before / After

Link fixed, formatting fixed. 

## Test Plan

Tested and built locally, but will have to confirm on dev.


