### PR TITLE
Changing the URL and name for PayIDValidator to PayStringValidator.

### DIFF
--- a/docs/aws-lambda-deploy.md
+++ b/docs/aws-lambda-deploy.md
@@ -129,7 +129,7 @@ Paste the values you saw in the previous step into wherever your registrar allow
 
 ## Test your PayID server
 
-Use [PayID Validator](https://payidvalidator.com/) to test your PayIDs.
+Use [PayString Validator](https://paystringvalidator.com/) to test your PayStrings.
 
 ## Launch with AWS Lambda using scripts
 

--- a/docs/community-resources.md
+++ b/docs/community-resources.md
@@ -12,7 +12,7 @@ Members of the PayID community have created useful resources for using and learn
 
 **Validators**
 
-- [PayID Validator](https://payidvalidator.com/) - An [open-source project](https://github.com/rswarthout/payid-validator) that validates responses using [JSON schemas](https://docs.payid.org/payid-interfaces) and verifies whether your PayID server follows various [best practices](payid-best-practices), like:
+- [PayString Validator](https://paystringvalidator.com/) - An [open-source project](https://github.com/rswarthout/paystring-validator) that validates responses using [JSON schemas](https://docs.payid.org/payid-interfaces) and verifies whether your PayID server follows various [best practices](payid-best-practices), like:
 
   - [HTTP response headers](payid-headers)
   - [Cache-Control](payid-best-practices#cache-control)


### PR DESCRIPTION
## High Level Overview of Change

The title pretty much says it, changing the name and domain name for the validator.